### PR TITLE
Older versions of Firefox and Safari experience exception Unsupported…

### DIFF
--- a/src/Request/Body/Body.php
+++ b/src/Request/Body/Body.php
@@ -23,7 +23,7 @@ abstract class Body
         }
 
         switch ($_SERVER['CONTENT_TYPE']) {
-            case ContentType::JSON:
+            case ContentType::JSON || ContentType::JSON_UTF8:
                 return new JsonBody($content);
             case ContentType::MULTIPART_FORMDATA:
                 return new FormDataBody($_POST);

--- a/src/Request/Body/Body.php
+++ b/src/Request/Body/Body.php
@@ -23,7 +23,8 @@ abstract class Body
         }
 
         switch ($_SERVER['CONTENT_TYPE']) {
-            case ContentType::JSON || ContentType::JSON_UTF8:
+            case ContentType::JSON:
+            case ContentType::JSON_UTF8:
                 return new JsonBody($content);
             case ContentType::MULTIPART_FORMDATA:
                 return new FormDataBody($_POST);

--- a/src/Response/Content/ContentType.php
+++ b/src/Response/Content/ContentType.php
@@ -5,6 +5,7 @@ abstract class ContentType
 {
     const MULTIPART_FORMDATA = 'multipart/form-data';
     const JSON = 'application/json';
+    const JSON_UTF8 = 'application/json; charset=UTF-8';
     const PDF = 'application/pdf';
 
     /**
@@ -15,7 +16,7 @@ abstract class ContentType
     public static function fromString($type): ContentType
     {
         switch ($type) {
-            case self::JSON:
+            case self::JSON || self::JSON_UTF8:
                 return new JsonContentType();
             case self::PDF:
                 return new PdfContentType();

--- a/src/Response/Content/ContentType.php
+++ b/src/Response/Content/ContentType.php
@@ -16,7 +16,8 @@ abstract class ContentType
     public static function fromString($type): ContentType
     {
         switch ($type) {
-            case self::JSON || self::JSON_UTF8:
+            case self::JSON:
+            case self::JSON_UTF8:
                 return new JsonContentType();
             case self::PDF:
                 return new PdfContentType();


### PR DESCRIPTION
…RequestBodyException because the ContentType is "application/json; charset=UTF-8" instead of just "application/json;"

Probably needs to be done in another way or refactored but to raise the problem we have in production